### PR TITLE
Misc cleanups + regenerate initramfs (to pick up ostree changes)

### DIFF
--- a/eln-dev/Containerfile
+++ b/eln-dev/Containerfile
@@ -1,5 +1,6 @@
 FROM quay.io/centos-bootc/fedora-bootc:eln
 COPY *.repo /etc/yum.repos.d/
 RUN dnf --disablerepo='*' --enablerepo=copr-coreos-continuous --enablerepo=copr-rhcontainerbot-bootc -y distro-sync && \
-    dnf clean all && rm -rf /var/* && \
-    ostree container commit
+    dnf clean all
+# Note we need to regenerate the initramfs because ostree is included in it
+RUN set -x; kver=$(cd /usr/lib/modules && echo *); dracut -vf /usr/lib/modules/$kver/initramfs.img $kver

--- a/stream9-dev/Containerfile
+++ b/stream9-dev/Containerfile
@@ -1,5 +1,4 @@
 FROM quay.io/centos-bootc/centos-bootc:stream9
 COPY *.repo /etc/yum.repos.d/
 RUN dnf --disablerepo='*' --enablerepo=copr-coreos-continuous --enablerepo=copr-rhcontainerbot-bootc -y distro-sync && \
-    rpm -q bootc || dnf -y install bootc && \
     dnf clean all

--- a/stream9-dev/Containerfile
+++ b/stream9-dev/Containerfile
@@ -2,3 +2,5 @@ FROM quay.io/centos-bootc/centos-bootc:stream9
 COPY *.repo /etc/yum.repos.d/
 RUN dnf --disablerepo='*' --enablerepo=copr-coreos-continuous --enablerepo=copr-rhcontainerbot-bootc -y distro-sync && \
     dnf clean all
+# Note we need to regenerate the initramfs because ostree is included in it
+RUN set -x; kver=$(cd /usr/lib/modules && echo *); dracut -vf /usr/lib/modules/$kver/initramfs.img $kver

--- a/stream9-dev/Containerfile
+++ b/stream9-dev/Containerfile
@@ -2,5 +2,4 @@ FROM quay.io/centos-bootc/centos-bootc:stream9
 COPY *.repo /etc/yum.repos.d/
 RUN dnf --disablerepo='*' --enablerepo=copr-coreos-continuous --enablerepo=copr-rhcontainerbot-bootc -y distro-sync && \
     rpm -q bootc || dnf -y install bootc && \
-    dnf clean all && rm -rf /var/* && \
-    ostree container commit
+    dnf clean all


### PR DESCRIPTION
Drop ostree container commit and `rm /var/*`

We're moving away from requiring this.

---

Drop bootc install

We can rely on it being in the image by default now.

---

Regenerate the initramfs because it includes ostree

This also serves as a test case of regenerating the initramfs in a container.

---

eln: sync with stream9

(We should probably only have one file and use buildah --from, but
 that can be a followup)

---

