### PR TITLE
Enable composefs + transient root

### DIFF
--- a/eln-dev/Containerfile
+++ b/eln-dev/Containerfile
@@ -1,4 +1,5 @@
 FROM quay.io/centos-bootc/fedora-bootc:eln
+COPY usr usr
 COPY *.repo /etc/yum.repos.d/
 RUN dnf --disablerepo='*' --enablerepo=copr-coreos-continuous --enablerepo=copr-rhcontainerbot-bootc -y distro-sync && \
     dnf clean all

--- a/eln-dev/usr/lib/ostree/prepare-root.conf
+++ b/eln-dev/usr/lib/ostree/prepare-root.conf
@@ -1,0 +1,4 @@
+[root]
+transient = true
+[composefs]
+enabled = true

--- a/stream9-dev/Containerfile
+++ b/stream9-dev/Containerfile
@@ -1,4 +1,5 @@
 FROM quay.io/centos-bootc/centos-bootc:stream9
+COPY usr usr
 COPY *.repo /etc/yum.repos.d/
 RUN dnf --disablerepo='*' --enablerepo=copr-coreos-continuous --enablerepo=copr-rhcontainerbot-bootc -y distro-sync && \
     dnf clean all

--- a/stream9-dev/usr/lib/ostree/prepare-root.conf
+++ b/stream9-dev/usr/lib/ostree/prepare-root.conf
@@ -1,0 +1,4 @@
+[root]
+transient = true
+[composefs]
+enabled = true


### PR DESCRIPTION
Let's enable this in our -dev images right now to try to put together our new recommended default experience.