### PR TITLE
Drop transient root

### DIFF
--- a/eln-dev/usr/lib/ostree/prepare-root.conf
+++ b/eln-dev/usr/lib/ostree/prepare-root.conf
@@ -1,4 +1,2 @@
-[root]
-transient = true
 [composefs]
 enabled = true

--- a/stream9-dev/usr/lib/ostree/prepare-root.conf
+++ b/stream9-dev/usr/lib/ostree/prepare-root.conf
@@ -1,4 +1,2 @@
-[root]
-transient = true
 [composefs]
 enabled = true


### PR DESCRIPTION
This just enables composefs.

Per discussion for now we will just document the existing `bootc usroverlay` etc., but we also need to fix https://github.com/ostreedev/ostree/issues/3177